### PR TITLE
Finding composer path

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -12,7 +12,13 @@ if [ ${branchName} == "master" ]; then
     echo ""
 fi
 
-composer.phar install -o --no-dev || (echo "Composer did not succeed." && exit 1)
+composer_executable=`which composer`
+if [ $? != 0 ]; then
+    echo "Composer is not installed globally falling back to local install"
+    composer.phar install -o --no-dev || (echo "Composer did not succeed." && exit 1)
+else
+    ${composer_executable} install -o --no-dev || (echo "Composer did not succeed." && exit 1)
+fi;
 
 if [ ! -f ./config.php ]; then
     echo -n "Copying config.php.dist to config.php"

--- a/bin/install
+++ b/bin/install
@@ -15,9 +15,14 @@ fi
 composer_executable=`which composer`
 if [ $? != 0 ]; then
     echo "Composer is not installed globally falling back to local install"
-    composer.phar install -o --no-dev || (echo "Composer did not succeed." && exit 1)
+    composer.phar install -o --no-dev
 else
-    ${composer_executable} install -o --no-dev || (echo "Composer did not succeed." && exit 1)
+    ${composer_executable} install -o --no-dev
+fi;
+
+if [ $? != 0 ]; then
+    echo "Composer did not succeed."
+    exit 1
 fi;
 
 if [ ! -f ./config.php ]; then


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

In the previous version of the setup if composer was installed globally the install script didn't work because it relies on a `composer.phar` file. Now it checks where composer is installed an executes it from there. And before it wasn't breaking properly after a failed run of composer which is also now fixed in the current version.
